### PR TITLE
Move data.table to Imports:

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,13 +67,13 @@ Imports:
     phangorn,
     uuid,
     stringi,
-    ggraph
+    ggraph,
+    data.table (>= 1.12.6)
 Depends:
     R (>= 4.0.0),
     ggplot2 (>= 3.1.0),
     dplyr (>= 0.8.0),
     dtplyr (>= 1.0.0),
-    data.table (>= 1.12.6),
     patchwork
 LinkingTo: Rcpp
 Suggests:

--- a/R/io-parsers.R
+++ b/R/io-parsers.R
@@ -1132,31 +1132,31 @@ parse_10x_filt_contigs <- function(.filename, .mode) {
     group_by_colnames("CDR3.nt.sorted", "V.name.sorted", "J.name.sorted") %>%
     summarise(
       Clones = length(unique(get("barcode"))),
-      CDR3.nt = first(get("CDR3.nt")),
-      CDR3.aa = first(get("CDR3.aa")),
-      V.name = first(get("V.name")),
-      D.name = first(get("D.name")),
-      J.name = first(get("J.name")),
-      chain = first(get("chain")),
+      CDR3.nt = dplyr::first(get("CDR3.nt")),
+      CDR3.aa = dplyr::first(get("CDR3.aa")),
+      V.name = dplyr::first(get("V.name")),
+      D.name = dplyr::first(get("D.name")),
+      J.name = dplyr::first(get("J.name")),
+      chain = dplyr::first(get("chain")),
       barcode = paste0(unique(get("barcode")), collapse = IMMCOL_ADD$scsep),
       raw_clonotype_id = gsub(
         "clonotype|None", "",
         paste0(unique(get("raw_clonotype_id")), collapse = IMMCOL_ADD$scsep)
       ),
       contig_id = paste0(get("contig_id"), collapse = IMMCOL_ADD$scsep),
-      c_gene = first(get("c_gene")),
-      CDR1.nt = first(get(IMMCOL_EXT$cdr1nt)),
-      CDR2.nt = first(get(IMMCOL_EXT$cdr2nt)),
-      CDR1.aa = first(get(IMMCOL_EXT$cdr1aa)),
-      CDR2.aa = first(get(IMMCOL_EXT$cdr2aa)),
-      FR1.nt = first(get(IMMCOL_EXT$fr1nt)),
-      FR2.nt = first(get(IMMCOL_EXT$fr2nt)),
-      FR3.nt = first(get(IMMCOL_EXT$fr3nt)),
-      FR4.nt = first(get(IMMCOL_EXT$fr4nt)),
-      FR1.aa = first(get(IMMCOL_EXT$fr1aa)),
-      FR2.aa = first(get(IMMCOL_EXT$fr2aa)),
-      FR3.aa = first(get(IMMCOL_EXT$fr3aa)),
-      FR4.aa = first(get(IMMCOL_EXT$fr4aa))
+      c_gene = dplyr::first(get("c_gene")),
+      CDR1.nt = dplyr::first(get(IMMCOL_EXT$cdr1nt)),
+      CDR2.nt = dplyr::first(get(IMMCOL_EXT$cdr2nt)),
+      CDR1.aa = dplyr::first(get(IMMCOL_EXT$cdr1aa)),
+      CDR2.aa = dplyr::first(get(IMMCOL_EXT$cdr2aa)),
+      FR1.nt = dplyr::first(get(IMMCOL_EXT$fr1nt)),
+      FR2.nt = dplyr::first(get(IMMCOL_EXT$fr2nt)),
+      FR3.nt = dplyr::first(get(IMMCOL_EXT$fr3nt)),
+      FR4.nt = dplyr::first(get(IMMCOL_EXT$fr4nt)),
+      FR1.aa = dplyr::first(get(IMMCOL_EXT$fr1aa)),
+      FR2.aa = dplyr::first(get(IMMCOL_EXT$fr2aa)),
+      FR3.aa = dplyr::first(get(IMMCOL_EXT$fr3aa)),
+      FR4.aa = dplyr::first(get(IMMCOL_EXT$fr4aa))
     ) %>%
     as.data.table() %>%
     subset(

--- a/R/seqCluster.R
+++ b/R/seqCluster.R
@@ -121,11 +121,11 @@ seqCluster <- function(.data, .dist, .perc_similarity, .nt_similarity, .fixed_th
       apply(., 1, function(x, t) {
         ifelse(x > t, NA, x)
       }, .y))
-    seq_clusters <- map(mat_dist, ~ melt(.x, na.rm = TRUE) %>%
+    seq_clusters <- map(mat_dist, ~ reshape2::melt(.x, na.rm = TRUE) %>%
       graph_from_data_frame() %>%
       clusters() %>%
       .$membership %>%
-      melt() %>%
+      reshape2::melt() %>%
       suppressWarnings())
     result_multi <- seq_clusters %>%
       map2(., seq_length[!singleseq_flag], ~ .x %>%

--- a/R/vis.R
+++ b/R/vis.R
@@ -2902,7 +2902,7 @@ vis.immunr_dynamics <- function(.data, .plot = c("smooth", "area", "line"), .ord
   }
 
   y_lab_title <- "Count"
-  melted <- melt(.data) %>%
+  melted <- reshape2::melt(.data) %>%
     lazy_dt() %>%
     rename(Count = value, Sample = variable) %>%
     collect()

--- a/tests/testthat/helper-preload.R
+++ b/tests/testthat/helper-preload.R
@@ -11,7 +11,7 @@ vis_results <- function(res_list, ...) {
 }
 
 check_for_mutation <- function(.frame, .table) {
-  expect_equal(lapply(.frame, as.data.table), .table)
+  expect_equal(lapply(.frame, data.table::as.data.table), .table)
 }
 
 # add pretfix
@@ -37,4 +37,4 @@ add_mock_sample <- function(.immdata, .sample_name, .meta = list(), .empty = FAL
 
 data(immdata)
 frame_data <- immdata$data
-table_data <- lapply(frame_data, as.data.table)
+table_data <- lapply(frame_data, data.table::as.data.table)

--- a/tests/testthat/test-filter.R
+++ b/tests/testthat/test-filter.R
@@ -270,7 +270,7 @@ for (i in seq_along(test_cases)) {
   test_name <- paste0("method:", method, ".case:", i)
   immdata <- data_factory()
   frame_with_meta <- immdata
-  table_with_meta <- list(data = lapply(immdata$data, as.data.table), meta = immdata$meta)
+  table_with_meta <- list(data = lapply(immdata$data, data.table::as.data.table), meta = immdata$meta)
 
   # Act
   if (is.null(match)) {
@@ -294,6 +294,6 @@ for (i in seq_along(test_cases)) {
       expected_rows <- expected_sample_rows[[j]]
       expect_equal(compute_res[[1]]$data[[sample_name]] %>% nrow(), expected_rows)
     }
-    expect_equal(lapply(compute_res[[1]]$data, as.data.table), compute_res[[2]]$data)
+    expect_equal(lapply(compute_res[[1]]$data, data.table::as.data.table), compute_res[[2]]$data)
   })
 }


### PR DESCRIPTION
Depends are discouraged for data.table:

https://github.com/Rdatatable/data.table/issues/3076

(in fact, we hope that R will eventually deprecate this mode of dependency)

I used {lintr} to find all {data.table} usages in your package.

```r
dt_exports <- getNamespaceExports("data.table")
dt_functions <- grep("^[a-zA-Z]", dt_exports, value=TRUE)
dt_operators <- grep("^[%]", dt_exports, value=TRUE)
lintr::lint_package(linters = list(
  lintr::undesirable_function_linter(setNames(nm = dt_functions)),
  lintr::undesirable_operator_linter(setNames(nm = dt_operators))
))
```

I added some qualifications of functions like `melt()` and `first()` that are also exported also by data.table to clarify their source, but could revert this if seen fit.

The qualifications in tests are needed as {data.table} is no longer attached for those.