### PR TITLE
Fix for upcoming purrr 1.2.0 release

### DIFF
--- a/R/seqCluster.R
+++ b/R/seqCluster.R
@@ -131,7 +131,7 @@ seqCluster <- function(.data, .dist, .perc_similarity, .nt_similarity, .fixed_th
       map2(., seq_length[!singleseq_flag], ~ .x %>%
         mutate(
           length_value = map_chr(.y, ~ ifelse(all(.x == .x[1]),
-            yes = .x[1],
+            yes = as.character(.x[1]),
             no = glue("range_{min(.x)}:{max(.x)}")
           ))
         )) %>%


### PR DESCRIPTION
`map_chr()` no longer automatically coerces to strings since this is a common source of bugs

I'm not 100% sure this is the correct fix since when I run your tests locally I see hundreds of warnings like this:

```
Warning ([test-diversity.R:36:7](vscode-file://vscode-app/Applications/Positron.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html#)): (code run outside of `test_that()`)
Warning! Sum of the input vector is NOT equal to 1. Function may produce incorrect results.
 To fix this try to set .do.norm = TRUE in the function's parameters.
```